### PR TITLE
Stream without subscriber should not send events

### DIFF
--- a/sembast/lib/src/listener.dart
+++ b/sembast/lib/src/listener.dart
@@ -157,7 +157,7 @@ class RecordListenerController<K, V> {
 
   /// Add a snapshot.
   void add(RecordSnapshot snapshot) {
-    if (isClosed) {
+    if (isClosed || !_streamController.hasListener) {
       return;
     }
     hasInitialData = true;
@@ -166,7 +166,7 @@ class RecordListenerController<K, V> {
 
   /// Add an error.
   void addError(dynamic error, StackTrace stackTrace) {
-    if (isClosed) {
+    if (isClosed || !_streamController.hasListener) {
       return;
     }
     _streamController?.addError(error, stackTrace);


### PR DESCRIPTION
Currently, when the application calls `onSnapshot` and doesn't follow up with `listen`, Sembast still sends all the events even though there are no subscribers. This can easily lead to memory leak if an application wants to setup multiple streams but use only some of them.

As per Dart rule (https://dart.dev/articles/libraries/creating-streams#waiting-for-a-subscription), Stream should only send events after the first subscription to prevent memory leak.

This PR adds a check if a stream has a listener before sending an event.