### PR TITLE
Add operators &, | for `Filter`

### DIFF
--- a/sembast/doc/queries.md
+++ b/sembast/doc/queries.md
@@ -25,7 +25,7 @@ var records = await store.records([key2, key3]).get(db);
 expect(records[0], {'name': 'cat'});
 expect(records[1], {'name': 'dog'});
 ```
- 
+
 
 ## Modify a read result
 
@@ -56,7 +56,7 @@ map['name'] = 'nice fish';
 Filtering and sorting can be done on any field
 
 ```dart
- // Look for any animal "greater than" (alphabetically) 'cat'
+// Look for any animal "greater than" (alphabetically) 'cat'
 // ordered by name
 var finder = Finder(
   filter: Filter.greaterThan('name', 'cat'),
@@ -139,14 +139,25 @@ var finder = Finder(filter: Filter.equals('product.code', 'AF8'));
 
 ### Composite filter
 
-You can combine multiple filters using `Filter.or` or `Filter.and`
+You can combine multiple filters using the operators `&` and `|`:
 
 ```dart
-filter = Filter.and([
+var filterAnd = Filter.greaterThan(Field.value, "hi") &
+    Filter.lessThan(Field.value, "hum");
+var filterOr = Filter.lessThan(Field.value, "hi") |
+    Filter.greaterThan(Field.value, "hum");
+```
+
+
+If you have more than two filters, you can also use `Filter.or` and `Filter.and`:
+```dart
+var filter = Filter.and([
   Filter.greaterThan(Field.value, "hi"),
-  Filter.lessThan(Field.value, "hum")
+  Filter.lessThan(Field.value, "hum"),
+  Filter.notEquals(Field.value, "ho"),
 ]);
 ```
+
 ### Using boundaries for paging
 
 `start` and `end` can specify a start and end boundary, similar to firestore

--- a/sembast/lib/src/api/filter.dart
+++ b/sembast/lib/src/api/filter.dart
@@ -66,9 +66,13 @@ abstract class Filter {
   }
 
   /// Record must match any of the given [filters].
+  ///
+  /// If you only have two filters, you can also write `filter1 | filter2`.
   factory Filter.or(List<Filter> filters) => SembastCompositeFilter.or(filters);
 
   /// Record must match all of the given [filters].
+  ///
+  /// If you only have two filters, you can also write `filter1 & filter2`.
   factory Filter.and(List<Filter> filters) =>
       SembastCompositeFilter.and(filters);
 
@@ -81,4 +85,17 @@ abstract class Filter {
   /// provides a raw access to the record internal value for efficiency.
   factory Filter.custom(bool Function(RecordSnapshot record) matches) =>
       SembastCustomFilter(matches);
+}
+
+/// Provides convenience methods for combining multiple [Filter]s.
+extension FilterCombination on Filter {
+  /// Record must match this or [other] filter.
+  ///
+  /// Use [Filter.or] to combine more than two filters.
+  Filter operator |(Filter other) => SembastCompositeFilter.or([this, other]);
+
+  /// Record must match this and [other] filter.
+  ///
+  /// Use [Filter.and] to combine more than two filters.
+  Filter operator &(Filter other) => SembastCompositeFilter.and([this, other]);
 }

--- a/sembast/lib/src/api/filter.dart
+++ b/sembast/lib/src/api/filter.dart
@@ -88,7 +88,7 @@ abstract class Filter {
 }
 
 /// Provides convenience methods for combining multiple [Filter]s.
-extension FilterCombination on Filter {
+extension SembastFilterCombination on Filter {
   /// Record must match this or [other] filter.
   ///
   /// Use [Filter.or] to combine more than two filters.


### PR DESCRIPTION
Great package! For better readability of composed filters, I added overloaded `&` (and) and `|` (or) operators to the `Filter` class. You can now write
``` dart
Filter.greaterThan(Field.value, "hi") & Filter.lessThan(Field.value, "hum")
```
instead of
```dart
Filter.and([Filter.greaterThan(Field.value, "hi"), Filter.lessThan(Field.value, "hum")])
```
(same for `Filter.or`).

As `Filter` is only implemented (and not extended) by `SembastFilterBase` (the base for concrete internal implementations like `SembastEqualsFilter`), I opted for adding these operators as extension methods instead of declaring them in `Filter` and implementing them in `SembastFilterBase`  (potentially breaking other implementations by users of this package).