### PR TITLE
Support NOT filters

### DIFF
--- a/sembast/lib/src/api/filter.dart
+++ b/sembast/lib/src/api/filter.dart
@@ -102,9 +102,4 @@ extension SembastFilterCombination on Filter {
   ///
   /// Use [Filter.and] to combine more than two filters.
   Filter operator &(Filter other) => SembastCompositeFilter.and([this, other]);
-
-  /// Record must not match this.
-  ///
-  /// Synonym fomr [Filter.not].
-  Filter operator !() => SembastOppositeFilter(this);
 }

--- a/sembast/lib/src/api/filter.dart
+++ b/sembast/lib/src/api/filter.dart
@@ -76,6 +76,10 @@ abstract class Filter {
   factory Filter.and(List<Filter> filters) =>
       SembastCompositeFilter.and(filters);
 
+  /// Record must not match the given [filter].
+  factory Filter.not(Filter filter) =>
+      SembastOppositeFilter(filter);
+
   /// Filter by [key].
   ///
   /// Less efficient than using `store.record(key)`.

--- a/sembast/lib/src/api/filter.dart
+++ b/sembast/lib/src/api/filter.dart
@@ -102,4 +102,9 @@ extension SembastFilterCombination on Filter {
   ///
   /// Use [Filter.and] to combine more than two filters.
   Filter operator &(Filter other) => SembastCompositeFilter.and([this, other]);
+
+  /// Record must not match this.
+  ///
+  /// Synonym fomr [Filter.not].
+  Filter operator !() => SembastOppositeFilter(this);
 }

--- a/sembast/lib/src/filter_impl.dart
+++ b/sembast/lib/src/filter_impl.dart
@@ -182,6 +182,25 @@ class SembastCompositeFilter extends SembastFilterBase {
   }
 }
 
+/// Opposite filter
+class SembastOppositeFilter extends SembastFilterBase {
+  // ignore: public_member_api_docs
+  Filter filter;
+
+  // ignore: public_member_api_docs
+  SembastOppositeFilter(this.filter);
+
+  @override
+  bool matchesRecord(RecordSnapshot record) {
+    return !(filter as SembastFilterBase).matchesRecord(record);
+  }
+
+  @override
+  String toString() {
+    return 'NOT $filter';
+  }
+}
+
 /// Filter predicate implementation.
 class SembastFilterPredicate extends SembastFilterBase
     with FilterValueMixin, FilterFieldMixin {

--- a/sembast/test/src_filter_test.dart
+++ b/sembast/test/src_filter_test.dart
@@ -102,6 +102,15 @@ void main() {
       expect(_match(filter, {'test': 3}), isFalse);
     });
 
+    test('not', () {
+      var filter =
+          Filter.not(Filter.equals('test', 2));
+      expect(_match(filter, {'test': 1}), isTrue);
+      expect(_match(filter, {'test': 2}), isFalse);
+      expect(_match(filter, {'test': 3}), isTrue);
+    });
+
+
     final alwaysMatchFilter = Filter.custom((_) => true);
     final neverMatchFilter = Filter.custom((_) => false);
 


### PR DESCRIPTION
Currently, Sembast misses a NOT filter and the "as SembastFilterBase" cast in Filter implementations makes it difficult to come up with a clean solution outside of Sembast. SembastCustomFilter could be used but it does not compose well with other filters.