### PR TITLE
Update sembast_import_export.dart

### DIFF
--- a/sembast/lib/utils/sembast_import_export.dart
+++ b/sembast/lib/utils/sembast_import_export.dart
@@ -58,7 +58,7 @@ Future<Map<String, Object?>> exportDatabase(Database db,
       for (var record in store.currentRecords) {
         keys.add(record.key);
         values.add(sembastDatabase.toJsonEncodable(record.value!));
-        if (sembastDatabase.cooperator!.needCooperate) {
+        if (sembastDatabase.cooperator != null && sembastDatabase.cooperator!.needCooperate) {
           await sembastDatabase.cooperator!.cooperate();
         }
       }


### PR DESCRIPTION
Attempt to fix
> Null check operator used on a null value

When calling `exportDatabase` I receive the error above.
This fixes the error and the database is exported successfully.

I'm not entirely sure *why* the `cooperator` is null at this point, but this fix seems to be harmless.