### PR TITLE
Add warning to the encryption example file

### DIFF
--- a/sembast_test/lib/encrypt_codec.dart
+++ b/sembast_test/lib/encrypt_codec.dart
@@ -15,6 +15,8 @@ Uint8List _randBytes(int length) {
       List<int>.generate(length, (i) => _random.nextInt(256)));
 }
 
+/// FOR DEMONSTRATION PURPOSES ONLY -- THIS IMPLEMENTATION IS INSECURE!
+///
 /// Generate an encryption password based on a user input password
 ///
 /// It uses MD5 which generates a 16 bytes blob, size needed for Salsa20


### PR DESCRIPTION
This is an excellent demonstration on how to bring encryption to sembast, but it is an entirely insecure implementation. The encryption is unauthenticated, the password conversion to bytes is massively underpowered (password hashes like bcyrpt, scrypt, argon2id, and pbkdf2 are some examples of correct algorithms), and the random bytes generator doesn't use a cryptographically secure source of randomness. I don't think that you should actually supply a production-ready version of encryption. But this is enough to help anyone see how the pieces should work.