### PR TITLE
abstract wrapper right before christmas

### DIFF
--- a/sembast/lib/src/wrapper.dart
+++ b/sembast/lib/src/wrapper.dart
@@ -1,0 +1,9 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:sembast/sembast.dart' show Database;
+
+/// a class for using composition, i.e. handling multiple sembast dbs
+abstract class Wrapper {
+  final Database db;
+  const Wrapper(this.db);
+}

--- a/sembast/lib/wrapper.dart
+++ b/sembast/lib/wrapper.dart
@@ -1,0 +1,4 @@
+library wrapper;
+
+/// The API
+export 'package:sembast/src/wrapper.dart';


### PR DESCRIPTION
Hi @alextekartik,

Could you consider exposing this wrapper inside Sembast package ?
This would make it easier to use dbs accross projects.
The use case here is adding persistence to [aptabase](https://github.com/flutter-painter/aptabase_flutter) to store events and send them once back online.
The idea is that Aptabase only exposes the eventsservices, not the database, which is passed by the client.
This avoids duplicating the db tasks and lets devs set-up this service within their own state-management.
Having a common wrapper class would allow devs to use a dedicated db.