### PR TITLE
fix: null check on null value

### DIFF
--- a/sembast/lib/src/io/file_system_io.dart
+++ b/sembast/lib/src/io/file_system_io.dart
@@ -82,7 +82,7 @@ class _IoOSError implements fs.OSError {
 class _IoFileSystemException implements fs.FileSystemException {
   io.FileSystemException ioFse;
 
-  _IoFileSystemException(this.ioFse) : osError = _IoOSError(ioFse.osError!);
+  _IoFileSystemException(this.ioFse) : osError = _IoOSError(ioFse.osError ?? ?? io.OSError(ioFse.message));
 
   @override
   final _IoOSError osError;

--- a/sembast/lib/src/io/file_system_io.dart
+++ b/sembast/lib/src/io/file_system_io.dart
@@ -82,7 +82,7 @@ class _IoOSError implements fs.OSError {
 class _IoFileSystemException implements fs.FileSystemException {
   io.FileSystemException ioFse;
 
-  _IoFileSystemException(this.ioFse) : osError = _IoOSError(ioFse.osError ?? ?? io.OSError(ioFse.message));
+  _IoFileSystemException(this.ioFse) : osError = _IoOSError(ioFse.osError ?? io.OSError(ioFse.message));
 
   @override
   final _IoOSError osError;


### PR DESCRIPTION
0
#0 new _IoFileSystemException (package:sembast/src/io/file_system_io.dart:85)
1
#1 _wrap.<anonymous closure> (package:sembast/src/io/file_system_io.dart:119)
2
#2 _rootRunBinary (dart:async/zone.dart:1423)
3
#3 _CustomZone.runBinary (dart:async/zone.dart:1315)
4
#4 _FutureListener.handleError (dart:async/future_impl.dart:177)
5
#5 Future._propagateToListeners.handleError (dart:async/future_impl.dart:850)
6
#6 Future._propagateToListeners (dart:async/future_impl.dart:871)
7
#7 Future._completeError (dart:async/future_impl.dart:651)
8
#8 Future._chainForeignFuture.<anonymous closure> (dart:async/future_impl.dart:556)
9
#9 _rootRun (dart:async/zone.dart:1399)
10
#10 _CustomZone.run (dart:async/zone.dart:1301)
11
#11 _CustomZone.runGuarded (dart:async/zone.dart:1209)
12
#12 _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1249)
13
#13 _microtaskLoop (dart:async/schedule_microtask.dart:40)
14
#14 _startMicrotaskLoop (dart:async/schedule_microtask.dart:49)
15
Null check operator used on a null value