### PR TITLE
Update README.md

### DIFF
--- a/sembast/README.md
+++ b/sembast/README.md
@@ -41,7 +41,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:sembast/sembast_io.dart';
 
 // get the application documents directory
-final dir = await getApplicationDocumentsDirectory();
+final dir = await getApplicationSupportDirectory();
 // make sure it exists
 await dir.create(recursive: true);
 // build the database path


### PR DESCRIPTION
Users of this library have been complaining that the database is not removed when uninstalling the app. This is probably due to the fact that the quick start recommends the `getApplicationDocumentsDirectory`. This is incorrect.

This PR changes the recommendation to `getApplicationSupportDirectory`

