### PR TITLE
docs(readme): replace pub.dartlang.org with pub.dev; normalize macOS; update Flutter docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sembast
 
-[![pub package](https://img.shields.io/pub/v/sembast.svg)](https://pub.dartlang.org/packages/sembast)
+[![pub package](https://img.shields.io/pub/v/sembast.svg)](https://pub.dev/packages/sembast)
 [![Build Status](https://travis-ci.org/tekartik/sembast.dart.svg?branch=master)](https://travis-ci.org/tekartik/sembast.dart)
 [![codecov](https://codecov.io/gh/tekartik/sembast.dart/branch/master/graph/badge.svg)](https://codecov.io/gh/tekartik/sembast.dart)
 


### PR DESCRIPTION
Small documentation cleanup in README:
- Replace legacy `pub.dartlang.org` links with `pub.dev`
- Normalize platform spelling `MacOS` -> `macOS`
- Update `flutter.dev/docs/...` links to `docs.flutter.dev/...`

No code changes.